### PR TITLE
fix: 修复 Header 深色模式图标定位问题

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -97,13 +97,13 @@ export function Header() {
           aria-label={t('header.theme')}
           title={getThemeTitle()}
         >
-          <div className="relative">
+          <div className="relative h-4 w-4">
             {theme === 'system' ? (
               <Monitor className="h-4 w-4" />
             ) : (
               <>
-                <Sun className="h-4 w-4 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
-                <Moon className="absolute left-0 h-4 w-4 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+                <Sun className="absolute inset-0 h-4 w-4 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+                <Moon className="absolute inset-0 h-4 w-4 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
               </>
             )}
           </div>


### PR DESCRIPTION
## 问题描述
深色模式下，Header 中的主题切换图标位置不正确，原因是 CSS 类名错误（使用了 `left-0` 而非 `inset-0`）。

## 修复内容
- 将 Moon 图标的 `left-0` 改为 `inset-0`
- 为外层 div 补充了 `h-4 w-4` 来约束图标尺寸

## 测试
已在本地验证，深色模式下图标显示正常。