### PR TITLE
fix(dev.py): auto-start Docker and clean stale __pycache__

### DIFF
--- a/scripts/dev.py
+++ b/scripts/dev.py
@@ -238,6 +238,16 @@ def spawn_background(name: str, cmd: list[str], cwd: Path, env: dict) -> int:
     return proc.pid
 
 
+def clean_pycache(directory: Path) -> int:
+    """递归清理 __pycache__ 目录，返回清理数量。"""
+    count = 0
+    for cache_dir in directory.rglob("__pycache__"):
+        if cache_dir.is_dir():
+            shutil.rmtree(cache_dir, ignore_errors=True)
+            count += 1
+    return count
+
+
 def tail_file(path: Path, lines: int = 50) -> str:
     """读取文件最后 N 行。"""
     if not path.exists():
@@ -331,12 +341,40 @@ def cmd_start() -> int:
             info(f"  {tool:8s} MISSING - {hint}")
             errors.append(tool)
 
-    # docker 是否在运行
+    # docker 是否在运行，未运行则自动启动
     if which("docker"):
         r = run_cmd(["docker", "info"])
         if r.returncode != 0:
-            info("  docker   NOT RUNNING - Please start Docker Desktop")
-            errors.append("docker-running")
+            info("  docker   NOT RUNNING - Starting Docker ...")
+            if IS_WIN:
+                candidates = [
+                    Path(os.environ.get("ProgramFiles", r"C:\Program Files")) / "Docker" / "Docker" / "Docker Desktop.exe",
+                    Path(os.environ.get("LOCALAPPDATA", "")) / "Docker" / "Docker Desktop.exe",
+                ]
+                docker_exe = next((p for p in candidates if p.exists()), None)
+                if docker_exe:
+                    subprocess.Popen([str(docker_exe)], creationflags=subprocess.CREATE_NO_WINDOW)
+                else:
+                    subprocess.Popen("start \"\" \"Docker Desktop\"", shell=True)
+            elif sys.platform == "darwin":
+                subprocess.Popen(["open", "-a", "Docker"])
+            else:
+                r = subprocess.run(
+                    ["systemctl", "start", "docker"],
+                    capture_output=True, timeout=10,
+                )
+                if r.returncode != 0:
+                    info("  docker   Failed to start (try: sudo systemctl start docker)")
+                    errors.append("docker-running")
+            if "docker-running" not in errors:
+                for i in range(30):
+                    time.sleep(2)
+                    if run_cmd(["docker", "info"]).returncode == 0:
+                        info("  docker   OK (auto-started)")
+                        break
+                else:
+                    info("  docker   TIMEOUT - failed to start within 60s")
+                    errors.append("docker-running")
 
     # .env
     if (ROOT / ".env").exists():
@@ -375,6 +413,11 @@ def cmd_start() -> int:
             return fe_install.returncode
     else:
         info("Frontend deps OK")
+
+    # 清理 __pycache__，防止 git pull 后旧字节码缓存导致运行旧代码
+    cleaned = clean_pycache(ROOT / "backend")
+    if cleaned:
+        info(f"Cleaned {cleaned} __pycache__ directories")
 
     # 3. Docker 基础设施
     step(3, total, "Starting infrastructure (PostgreSQL + Redis) ...")


### PR DESCRIPTION
## 背景与目标

`scripts/dev.py start` 在以下两种常见场景中体验不佳：

1. **Docker 未运行**：直接报错退出，用户需手动启动 Docker Desktop 后重试
2. **`git pull` 后旧 `__pycache__`**：uvicorn reload 可能加载旧 `.pyc` 字节码，导致运行时行为与源码不一致（例如 schema 字段数量不匹配）

本 PR 让 `dev.py start` 自动处理这两种情况，减少用户手动干预。

## 本 PR 范围

仅修改 `scripts/dev.py`，新增约 45 行：

### 1. Docker 自动启动（跨平台）

| 平台 | 策略 |
|------|------|
| Windows | 搜索 `%ProgramFiles%` / `%LOCALAPPDATA%` 下的 Docker Desktop.exe，未找到则 fallback 到 `start` 命令 |
| macOS | `open -a Docker` |
| Linux | `systemctl start docker`，权限不足时提示 `sudo` |

启动后轮询 `docker info` 最多 60 秒，超时则报错退出。

### 2. `__pycache__` 自动清理

在依赖安装之后、Docker 基础设施启动之前，递归删除 `backend/` 下所有 `__pycache__` 目录。

## 明确不包含

- 不修改 Makefile、Docker Compose、前端代码
- 不新增 .bat / .ps1 脚本
- 不涉及新业务域、API 或端口变更

## 架构影响

无。纯行为增强，不改变架构或分层。

## 文档更新清单

无需更新。不涉及域、API、端口或目录结构变更。

## 验证命令与结果

```powershell
# Windows 验证（Docker Desktop 未运行状态下）
uv run python scripts/dev.py start
# 预期：自动启动 Docker Desktop，等待就绪后继续正常流程

# 验证 __pycache__ 清理
# 在 backend/ 下手动创建 __pycache__ 目录后运行 start
# 预期：日志输出 "Cleaned N __pycache__ directories"
```

## 风险点

- Windows Docker Desktop 非默认路径安装时，可能无法自动找到可执行文件 → 兜底使用 `start` 命令让系统查找
- Linux `systemctl start docker` 需要 root 权限 → 失败时打印明确提示而非静默等待超时

## 回滚方式

还原 `scripts/dev.py` 单文件即可恢复为原始"报错退出"行为。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)